### PR TITLE
feat: editable file names and Prettier formatting in gist editor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ jspm_packages/
 # Yarn (legacy)
 .yarn-integrity
 yarn.lock
+package-lock.json
 
 # dotenv environment variables file
 .env

--- a/.gitignore
+++ b/.gitignore
@@ -61,7 +61,6 @@ jspm_packages/
 # Yarn (legacy)
 .yarn-integrity
 yarn.lock
-package-lock.json
 
 # dotenv environment variables file
 .env

--- a/bun.lock
+++ b/bun.lock
@@ -26,6 +26,7 @@
         "clsx": "^2.1.1",
         "lucide-react": "^0.553.0",
         "postcss": "^8.4.49",
+        "prettier": "^3.8.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-icons": "^5.3.0",
@@ -121,23 +122,23 @@
 
     "@babel/types": ["@babel/types@7.28.5", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA=="],
 
-    "@biomejs/biome": ["@biomejs/biome@2.4.6", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.6", "@biomejs/cli-darwin-x64": "2.4.6", "@biomejs/cli-linux-arm64": "2.4.6", "@biomejs/cli-linux-arm64-musl": "2.4.6", "@biomejs/cli-linux-x64": "2.4.6", "@biomejs/cli-linux-x64-musl": "2.4.6", "@biomejs/cli-win32-arm64": "2.4.6", "@biomejs/cli-win32-x64": "2.4.6" }, "bin": { "biome": "bin/biome" } }, "sha512-QnHe81PMslpy3mnpL8DnO2M4S4ZnYPkjlGCLWBZT/3R9M6b5daArWMMtEfP52/n174RKnwRIf3oT8+wc9ihSfQ=="],
+    "@biomejs/biome": ["@biomejs/biome@2.4.10", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.10", "@biomejs/cli-darwin-x64": "2.4.10", "@biomejs/cli-linux-arm64": "2.4.10", "@biomejs/cli-linux-arm64-musl": "2.4.10", "@biomejs/cli-linux-x64": "2.4.10", "@biomejs/cli-linux-x64-musl": "2.4.10", "@biomejs/cli-win32-arm64": "2.4.10", "@biomejs/cli-win32-x64": "2.4.10" }, "bin": { "biome": "bin/biome" } }, "sha512-xxA3AphFQ1geij4JTHXv4EeSTda1IFn22ye9LdyVPoJU19fNVl0uzfEuhsfQ4Yue/0FaLs2/ccVi4UDiE7R30w=="],
 
-    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.6", "", { "os": "darwin", "cpu": "arm64" }, "sha512-NW18GSyxr+8sJIqgoGwVp5Zqm4SALH4b4gftIA0n62PTuBs6G2tHlwNAOj0Vq0KKSs7Sf88VjjmHh0O36EnzrQ=="],
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.10", "", { "os": "darwin", "cpu": "arm64" }, "sha512-vuzzI1cWqDVzOMIkYyHbKqp+AkQq4K7k+UCXWpkYcY/HDn1UxdsbsfgtVpa40shem8Kax4TLDLlx8kMAecgqiw=="],
 
-    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.6", "", { "os": "darwin", "cpu": "x64" }, "sha512-4uiE/9tuI7cnjtY9b07RgS7gGyYOAfIAGeVJWEfeCnAarOAS7qVmuRyX6d7JTKw28/mt+rUzMasYeZ+0R/U1Mw=="],
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.10", "", { "os": "darwin", "cpu": "x64" }, "sha512-14fzASRo+BPotwp7nWULy2W5xeUyFnTaq1V13Etrrxkrih+ez/2QfgFm5Ehtf5vSjtgx/IJycMMpn5kPd5ZNaA=="],
 
-    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-kMLaI7OF5GN1Q8Doymjro1P8rVEoy7BKQALNz6fiR8IC1WKduoNyteBtJlHT7ASIL0Cx2jR6VUOBIbcB1B8pew=="],
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.10", "", { "os": "linux", "cpu": "arm64" }, "sha512-7MH1CMW5uuxQ/s7FLST63qF8B3Hgu2HRdZ7tA1X1+mk+St4JOuIrqdhIBnnyqeyWJNI+Bww7Es5QZ0wIc1Cmkw=="],
 
-    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-F/JdB7eN22txiTqHM5KhIVt0jVkzZwVYrdTR1O3Y4auBOQcXxHK4dxULf4z43QyZI5tsnQJrRBHZy7wwtL+B3A=="],
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.10", "", { "os": "linux", "cpu": "arm64" }, "sha512-WrJY6UuiSD/Dh+nwK2qOTu8kdMDlLV3dLMmychIghHPAysWFq1/DGC1pVZx8POE3ZkzKR3PUUnVrtZfMfaJjyQ=="],
 
-    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.6", "", { "os": "linux", "cpu": "x64" }, "sha512-oHXmUFEoH8Lql1xfc3QkFLiC1hGR7qedv5eKNlC185or+o4/4HiaU7vYODAH3peRCfsuLr1g6v2fK9dFFOYdyw=="],
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.10", "", { "os": "linux", "cpu": "x64" }, "sha512-tZLvEEi2u9Xu1zAqRjTcpIDGVtldigVvzug2fTuPG0ME/g8/mXpRPcNgLB22bGn6FvLJpHHnqLnwliOu8xjYrg=="],
 
-    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.6", "", { "os": "linux", "cpu": "x64" }, "sha512-C9s98IPDu7DYarjlZNuzJKTjVHN03RUnmHV5htvqsx6vEUXCDSJ59DNwjKVD5XYoSS4N+BYhq3RTBAL8X6svEg=="],
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.10", "", { "os": "linux", "cpu": "x64" }, "sha512-kDTi3pI6PBN6CiczsWYOyP2zk0IJI08EWEQyDMQWW221rPaaEz6FvjLhnU07KMzLv8q3qSuoB93ua6inSQ55Tw=="],
 
-    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.6", "", { "os": "win32", "cpu": "arm64" }, "sha512-xzThn87Pf3YrOGTEODFGONmqXpTwUNxovQb72iaUOdcw8sBSY3+3WD8Hm9IhMYLnPi0n32s3L3NWU6+eSjfqFg=="],
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.10", "", { "os": "win32", "cpu": "arm64" }, "sha512-umwQU6qPzH+ISTf/eHyJ/QoQnJs3V9Vpjz2OjZXe9MVBZ7prgGafMy7yYeRGnlmDAn87AKTF3Q6weLoMGpeqdQ=="],
 
-    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.6", "", { "os": "win32", "cpu": "x64" }, "sha512-7++XhnsPlr1HDbor5amovPjOH6vsrFOCdp93iKXhFn6bcMUI6soodj3WWKfgEO6JosKU1W5n3uky3WW9RlRjTg=="],
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.10", "", { "os": "win32", "cpu": "x64" }, "sha512-aW/JU5GuyH4uxMrNYpoC2kjaHlyJGLgIa3XkhPEZI0uKhZhJZU8BuEyJmvgzSPQNGozBwWjC972RaNdcJ9KyJg=="],
 
     "@csstools/color-helpers": ["@csstools/color-helpers@6.0.2", "", {}, "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q=="],
 
@@ -417,7 +418,7 @@
 
     "ansi-regex": ["ansi-regex@https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz", {}],
 
-    "ansi-styles": ["ansi-styles@https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz", { "dependencies": { "color-convert": "^2.0.1" } }],
+    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "any-promise": ["any-promise@1.3.0", "", {}, "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="],
 
@@ -471,7 +472,7 @@
 
     "chai": ["chai@6.2.1", "", {}, "sha512-p4Z49OGG5W/WBCPSS/dH3jQ73kD6tiMmUM+bckNK6Jr5JHMG3k9bg/BvKR8lKmtVBKmOiuVaV2ws8s9oSbwysg=="],
 
-    "chalk": ["chalk@https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }],
+    "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "char-regex": ["char-regex@1.0.2", "", {}, "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw=="],
 
@@ -487,13 +488,13 @@
 
     "class-variance-authority": ["class-variance-authority@0.7.1", "", { "dependencies": { "clsx": "^2.1.1" } }, "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg=="],
 
-    "cliui": ["cliui@https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }],
+    "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
-    "color-convert": ["color-convert@https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz", { "dependencies": { "color-name": "~1.1.4" } }],
+    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
-    "color-name": ["color-name@https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz", {}],
+    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
     "colord": ["colord@2.9.3", "", {}, "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw=="],
 
@@ -503,7 +504,7 @@
 
     "commander": ["commander@9.5.0", "", {}, "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ=="],
 
-    "concurrently": ["concurrently@https://registry.npmjs.org/concurrently/-/concurrently-9.2.0.tgz", { "dependencies": { "chalk": "^4.1.2", "lodash": "^4.17.21", "rxjs": "^7.8.1", "shell-quote": "^1.8.1", "supports-color": "^8.1.1", "tree-kill": "^1.2.2", "yargs": "^17.7.2" } }],
+    "concurrently": ["concurrently@9.2.1", "", { "dependencies": { "chalk": "4.1.2", "rxjs": "7.8.2", "shell-quote": "1.8.3", "supports-color": "8.1.1", "tree-kill": "1.2.2", "yargs": "17.7.2" }, "bin": { "conc": "dist/bin/concurrently.js", "concurrently": "dist/bin/concurrently.js" } }, "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng=="],
 
     "content-disposition": ["content-disposition@0.5.4", "", { "dependencies": { "safe-buffer": "5.2.1" } }, "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ=="],
 
@@ -581,7 +582,7 @@
 
     "electron-to-chromium": ["electron-to-chromium@1.5.307", "", {}, "sha512-5z3uFKBWjiNR44nFcYdkcXjKMbg5KXNdciu7mhTPo9tB7NbqSNP2sSnGR+fqknZSCwKkBN+oxiiajWs4dT6ORg=="],
 
-    "emoji-regex": ["emoji-regex@https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz", {}],
+    "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "emojilib": ["emojilib@2.4.0", "", {}, "sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw=="],
 
@@ -603,7 +604,7 @@
 
     "esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
 
-    "escalade": ["escalade@https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz", {}],
+    "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
     "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
 
@@ -655,7 +656,7 @@
 
     "gensync": ["gensync@https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz", {}],
 
-    "get-caller-file": ["get-caller-file@https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz", {}],
+    "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
 
     "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
 
@@ -671,7 +672,7 @@
 
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
 
-    "has-flag": ["has-flag@https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz", {}],
+    "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
     "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
 
@@ -735,7 +736,7 @@
 
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
 
-    "is-fullwidth-code-point": ["is-fullwidth-code-point@https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz", {}],
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
 
     "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
 
@@ -762,8 +763,6 @@
     "lilconfig": ["lilconfig@3.1.3", "", {}, "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw=="],
 
     "lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
-
-    "lodash": ["lodash@https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz", {}],
 
     "lodash.memoize": ["lodash.memoize@4.1.2", "", {}, "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag=="],
 
@@ -1013,6 +1012,8 @@
 
     "postcss-value-parser": ["postcss-value-parser@4.2.0", "", {}, "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="],
 
+    "prettier": ["prettier@3.8.1", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg=="],
+
     "pretty-format": ["pretty-format@https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }],
 
     "prismjs": ["prismjs@1.30.0", "", {}, "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw=="],
@@ -1085,7 +1086,7 @@
 
     "remark-stringify": ["remark-stringify@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-to-markdown": "^2.0.0", "unified": "^11.0.0" } }, "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw=="],
 
-    "require-directory": ["require-directory@https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz", {}],
+    "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
 
     "require-from-string": ["require-from-string@https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz", {}],
 
@@ -1097,7 +1098,7 @@
 
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
 
-    "rxjs": ["rxjs@https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz", { "dependencies": { "tslib": "^2.1.0" } }],
+    "rxjs": ["rxjs@7.8.2", "", { "dependencies": { "tslib": "^2.1.0" } }, "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA=="],
 
     "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
@@ -1119,7 +1120,7 @@
 
     "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
 
-    "shell-quote": ["shell-quote@https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz", {}],
+    "shell-quote": ["shell-quote@1.8.3", "", {}, "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw=="],
 
     "showdown": ["showdown@2.1.0", "", { "dependencies": { "commander": "^9.0.0" }, "bin": { "showdown": "bin/showdown.js" } }, "sha512-/6NVYu4U819R2pUIk79n67SYgJHWCce0a5xTP979WbNp0FL9MN1I1QK662IDU1b6JzKTvmhgI7T7JYIxBi3kMQ=="],
 
@@ -1147,11 +1148,11 @@
 
     "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
 
-    "string-width": ["string-width@https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }],
+    "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
 
-    "strip-ansi": ["strip-ansi@https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz", { "dependencies": { "ansi-regex": "^5.0.1" } }],
+    "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "strip-indent": ["strip-indent@3.0.0", "", { "dependencies": { "min-indent": "^1.0.0" } }, "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ=="],
 
@@ -1163,7 +1164,7 @@
 
     "sucrase": ["sucrase@3.35.1", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.2", "commander": "^4.0.0", "lines-and-columns": "^1.1.6", "mz": "^2.7.0", "pirates": "^4.0.1", "tinyglobby": "^0.2.11", "ts-interface-checker": "^0.1.9" }, "bin": { "sucrase": "bin/sucrase", "sucrase-node": "bin/sucrase-node" } }, "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw=="],
 
-    "supports-color": ["supports-color@https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz", { "dependencies": { "has-flag": "^4.0.0" } }],
+    "supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q=="],
 
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
 
@@ -1203,7 +1204,7 @@
 
     "tr46": ["tr46@6.0.0", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw=="],
 
-    "tree-kill": ["tree-kill@https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz", {}],
+    "tree-kill": ["tree-kill@1.2.2", "", { "bin": { "tree-kill": "cli.js" } }, "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="],
 
     "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
 
@@ -1211,7 +1212,7 @@
 
     "ts-interface-checker": ["ts-interface-checker@0.1.13", "", {}, "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="],
 
-    "tslib": ["tslib@https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz", {}],
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "turndown": ["turndown@7.2.2", "", { "dependencies": { "@mixmark-io/domino": "^2.2.0" } }, "sha512-1F7db8BiExOKxjSMU2b7if62D/XOyQyZbPKq/nUwopfgnHlqXHqQ0lvfUTeUIr1lZJzOPFn43dODyMSIfvWRKQ=="],
 
@@ -1271,7 +1272,7 @@
 
     "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 
-    "wrap-ansi": ["wrap-ansi@https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }],
+    "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
     "ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
 
@@ -1281,15 +1282,15 @@
 
     "xtend": ["xtend@4.0.2", "", {}, "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="],
 
-    "y18n": ["y18n@https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz", {}],
+    "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
 
     "yallist": ["yallist@https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz", {}],
 
     "yaml": ["yaml@1.10.2", "", {}, "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="],
 
-    "yargs": ["yargs@https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }],
+    "yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
 
-    "yargs-parser": ["yargs-parser@https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz", {}],
+    "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
@@ -1353,13 +1354,11 @@
 
     "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
-    "aria-hidden/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
-
     "autoprefixer/picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "body-parser/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
-    "chalk/supports-color": ["supports-color@https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz", { "dependencies": { "has-flag": "^4.0.0" } }],
+    "chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
     "chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
@@ -1417,13 +1416,7 @@
 
     "pretty-format/ansi-styles": ["ansi-styles@https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz", {}],
 
-    "react-remove-scroll/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
-
-    "react-remove-scroll-bar/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
-
     "react-router/cookie": ["cookie@1.0.2", "", {}, "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA=="],
-
-    "react-style-singleton/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "react-syntax-highlighter/@babel/runtime": ["@babel/runtime@7.28.6", "", {}, "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA=="],
 
@@ -1437,6 +1430,8 @@
 
     "stringify-entities/character-entities-legacy": ["character-entities-legacy@3.0.0", "", {}, "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="],
 
+    "strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
     "stylehacks/postcss-selector-parser": ["postcss-selector-parser@7.1.1", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg=="],
 
     "sucrase/commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
@@ -1447,13 +1442,7 @@
 
     "tailwindcss/picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
-    "update-browserslist-db/escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
-
     "update-browserslist-db/picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
-
-    "use-callback-ref/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
-
-    "use-sidecar/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "vite/postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
 
@@ -1520,6 +1509,8 @@
     "vite/postcss/nanoid": ["nanoid@https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz", {}],
 
     "vite/postcss/source-map-js": ["source-map-js@https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz", {}],
+
+    "@babel/helper-compilation-targets/browserslist/update-browserslist-db/escalade": ["escalade@https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz", {}],
 
     "@babel/helper-module-imports/@babel/traverse/@babel/generator/@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }],
 

--- a/client/package.json
+++ b/client/package.json
@@ -16,6 +16,7 @@
     "clsx": "^2.1.1",
     "lucide-react": "^0.553.0",
     "postcss": "^8.4.49",
+    "prettier": "^3.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-icons": "^5.3.0",

--- a/client/src/components/GistEditor.jsx
+++ b/client/src/components/GistEditor.jsx
@@ -311,12 +311,42 @@ const MarkdownToolbar = ({ onInsert, activeFile }) => {
 };
 
 /**
+ * Resolves the Prettier parser name for a given file extension.
+ * @param {string} ext - Lowercase file extension (without dot)
+ * @returns {{ parser: string, plugins?: string[] } | null} Prettier config or null if unsupported
+ */
+const getPrettierConfig = (ext) => {
+	const map = {
+		js: { parser: 'babel' },
+		jsx: { parser: 'babel' },
+		mjs: { parser: 'babel' },
+		ts: { parser: 'typescript' },
+		tsx: { parser: 'typescript' },
+		css: { parser: 'css' },
+		scss: { parser: 'scss' },
+		less: { parser: 'less' },
+		html: { parser: 'html' },
+		htm: { parser: 'html' },
+		json: { parser: 'json' },
+		json5: { parser: 'json5' },
+		yaml: { parser: 'yaml' },
+		yml: { parser: 'yaml' },
+		md: { parser: 'markdown' },
+		markdown: { parser: 'markdown' },
+		mdx: { parser: 'mdx' },
+		graphql: { parser: 'graphql' },
+		gql: { parser: 'graphql' },
+	};
+	return map[ext] || null;
+};
+
+/**
  * Main GistEditor Component with Enhanced Split Panel
  */
 const GistEditor = () => {
 	const [gist, setGist] = useState({
 		description: '',
-		files: { 'newfile.md': { content: '' } },
+		files: { untitled: { content: '' } },
 		public: false,
 	});
 	const [loading, setLoading] = useState(false);
@@ -324,6 +354,9 @@ const GistEditor = () => {
 	const [previewMode, setPreviewMode] = useState('split');
 	const [wrapText, setWrapText] = useState(true);
 	const [activeFile, setActiveFile] = useState(null);
+	const [editingTab, setEditingTab] = useState(null);
+	const [editingName, setEditingName] = useState('');
+	const [formatting, setFormatting] = useState(false);
 
 	const { id } = useParams();
 	const navigate = useNavigate();
@@ -332,6 +365,7 @@ const GistEditor = () => {
 
 	const editorRef = useRef(null);
 	const previewRef = useRef(null);
+	const tabInputRef = useRef(null);
 
 	// Debounce preview content so large markdown doesn't block the editor
 	const [debouncedContent, setDebouncedContent] = useState('');
@@ -370,7 +404,9 @@ const GistEditor = () => {
 		if (id) {
 			fetchGist(id);
 		} else {
-			setActiveFile('newfile.md');
+			setActiveFile('untitled');
+			setEditingTab('untitled');
+			setEditingName('untitled');
 		}
 	}, [id, fetchGist]);
 
@@ -379,6 +415,14 @@ const GistEditor = () => {
 			setActiveFile(Object.keys(gist.files)[0]);
 		}
 	}, [gist, activeFile]);
+
+	// Auto-focus the tab input when entering edit mode
+	useEffect(() => {
+		if (editingTab && tabInputRef.current) {
+			tabInputRef.current.focus();
+			tabInputRef.current.select();
+		}
+	}, [editingTab]);
 
 	const handleSubmit = async (e) => {
 		e.preventDefault();
@@ -419,12 +463,58 @@ const GistEditor = () => {
 		setGist((prev) => ({ ...prev, files: { ...prev.files, [fileName]: { content } } }));
 	}, []);
 
+	/**
+	 * Renames a file in the gist state, preserving key order.
+	 * @param {string} oldName - Current filename
+	 * @param {string} newName - Desired filename
+	 */
+	const renameFile = useCallback(
+		(oldName, newName) => {
+			const trimmed = newName.trim();
+			if (!trimmed || trimmed === oldName) return;
+			if (gist.files[trimmed]) {
+				setError(`A file named "${trimmed}" already exists.`);
+				return;
+			}
+
+			setGist((prev) => {
+				const rebuilt = {};
+				for (const [key, value] of Object.entries(prev.files)) {
+					if (key === oldName) {
+						rebuilt[trimmed] = value;
+					} else {
+						rebuilt[key] = value;
+					}
+				}
+				return { ...prev, files: rebuilt };
+			});
+
+			if (activeFile === oldName) {
+				setActiveFile(trimmed);
+			}
+		},
+		[gist.files, activeFile],
+	);
+
+	/**
+	 * Commits the current tab rename and exits edit mode.
+	 */
+	const commitTabRename = useCallback(() => {
+		if (editingTab) {
+			renameFile(editingTab, editingName);
+			setEditingTab(null);
+			setEditingName('');
+		}
+	}, [editingTab, editingName, renameFile]);
+
 	const addNewFile = () => {
-		let name = 'newfile.md',
+		let name = 'untitled',
 			i = 1;
-		while (gist.files[name]) name = `newfile_${i++}.md`;
+		while (gist.files[name]) name = `untitled_${i++}`;
 		setGist((prev) => ({ ...prev, files: { ...prev.files, [name]: { content: '' } } }));
 		setActiveFile(name);
+		setEditingTab(name);
+		setEditingName(name);
 	};
 
 	const removeFile = (fn) => {
@@ -437,6 +527,73 @@ const GistEditor = () => {
 		setGist((prev) => ({ ...prev, files }));
 		if (activeFile === fn) setActiveFile(Object.keys(files)[0]);
 	};
+
+	/**
+	 * Formats the active file content using Prettier (loaded on demand).
+	 */
+	const formatActiveFile = useCallback(async () => {
+		if (!activeFile) return;
+		const ext = activeFile.includes('.') ? activeFile.split('.').pop().toLowerCase() : '';
+		const config = getPrettierConfig(ext);
+		if (!config) {
+			toast.error(`No formatter available for .${ext || '(no extension)'} files.`);
+			return;
+		}
+
+		setFormatting(true);
+		try {
+			const prettier = await import('prettier/standalone');
+			const plugins = [];
+
+			if (['babel', 'babel-ts'].includes(config.parser) || config.parser === 'typescript') {
+				const mod = await import('prettier/plugins/babel');
+				plugins.push(mod.default || mod);
+				const estree = await import('prettier/plugins/estree');
+				plugins.push(estree.default || estree);
+				if (config.parser === 'typescript') {
+					const tsMod = await import('prettier/plugins/typescript');
+					plugins.push(tsMod.default || tsMod);
+				}
+			} else if (['css', 'scss', 'less'].includes(config.parser)) {
+				const mod = await import('prettier/plugins/postcss');
+				plugins.push(mod.default || mod);
+			} else if (config.parser === 'html') {
+				const mod = await import('prettier/plugins/html');
+				plugins.push(mod.default || mod);
+			} else if (['markdown', 'mdx'].includes(config.parser)) {
+				const mod = await import('prettier/plugins/markdown');
+				plugins.push(mod.default || mod);
+			} else if (['yaml'].includes(config.parser)) {
+				const mod = await import('prettier/plugins/yaml');
+				plugins.push(mod.default || mod);
+			} else if (['graphql'].includes(config.parser)) {
+				const mod = await import('prettier/plugins/graphql');
+				plugins.push(mod.default || mod);
+			} else if (['json', 'json5'].includes(config.parser)) {
+				const estree = await import('prettier/plugins/estree');
+				plugins.push(estree.default || estree);
+				const mod = await import('prettier/plugins/babel');
+				plugins.push(mod.default || mod);
+			}
+
+			const formatted = await prettier.format(currentFileContent, {
+				parser: config.parser,
+				plugins,
+				useTabs: true,
+				tabWidth: 2,
+				printWidth: 100,
+				singleQuote: true,
+				trailingComma: 'all',
+			});
+			handleFileChange(activeFile, formatted);
+			toast.success('Formatted');
+		} catch (err) {
+			logError('Prettier format failed', err);
+			toast.error(`Format failed: ${err.message}`);
+		} finally {
+			setFormatting(false);
+		}
+	}, [activeFile, currentFileContent, handleFileChange, toast]);
 
 	const syncScroll = useCallback(
 		(e) => {
@@ -472,6 +629,12 @@ const GistEditor = () => {
 
 	useEffect(() => {
 		const onKeyDown = (e) => {
+			// Shift+Alt+F: format active file (works globally in editor)
+			if (e.shiftKey && e.altKey && e.key === 'F') {
+				e.preventDefault();
+				formatActiveFile();
+				return;
+			}
 			if (document.activeElement !== editorRef.current) return;
 			if (e.metaKey || e.ctrlKey) {
 				switch (e.key) {
@@ -502,13 +665,15 @@ const GistEditor = () => {
 		};
 		document.addEventListener('keydown', onKeyDown);
 		return () => document.removeEventListener('keydown', onKeyDown);
-	}, [insertText]);
+	}, [insertText, formatActiveFile]);
 
 	const isMarkdownFile = (fn) => fn?.match(/\.(md|markdown|mdx)$/i);
 	const getFileLanguage = (fn) => {
 		const ext = fn.split('.').pop().toLowerCase();
 		const map = {
 			js: 'javascript',
+			mjs: 'javascript',
+			cjs: 'javascript',
 			jsx: 'jsx',
 			ts: 'typescript',
 			tsx: 'tsx',
@@ -516,17 +681,51 @@ const GistEditor = () => {
 			rb: 'ruby',
 			java: 'java',
 			go: 'go',
+			rs: 'rust',
+			c: 'c',
+			cpp: 'cpp',
+			h: 'c',
+			hpp: 'cpp',
+			cs: 'csharp',
+			swift: 'swift',
+			kt: 'kotlin',
 			html: 'html',
+			htm: 'html',
 			css: 'css',
 			scss: 'scss',
+			less: 'less',
 			json: 'json',
 			yaml: 'yaml',
 			yml: 'yaml',
+			toml: 'toml',
+			xml: 'xml',
+			sql: 'sql',
+			graphql: 'graphql',
+			gql: 'graphql',
 			sh: 'bash',
+			bash: 'bash',
+			zsh: 'bash',
+			fish: 'bash',
+			ps1: 'powershell',
+			dockerfile: 'docker',
+			tf: 'hcl',
+			lua: 'lua',
+			r: 'r',
+			php: 'php',
+			pl: 'perl',
+			ex: 'elixir',
+			exs: 'elixir',
+			erl: 'erlang',
+			hs: 'haskell',
 			txt: 'text',
 		};
 		return map[ext] || 'text';
 	};
+
+	/** @returns {boolean} Whether the active file has a Prettier-supported extension */
+	const canFormat = activeFile
+		? getPrettierConfig(activeFile.includes('.') ? activeFile.split('.').pop().toLowerCase() : '')
+		: null;
 
 	// Add page class to body for layout targeting
 	useEffect(() => {
@@ -645,10 +844,37 @@ const GistEditor = () => {
 							key={filename}
 							type="button"
 							onClick={() => setActiveFile(filename)}
+							onDoubleClick={() => {
+								setEditingTab(filename);
+								setEditingName(filename);
+							}}
 							className={`tab ${activeFile === filename ? 'active' : ''}`}
+							title="Double-click to rename"
 						>
-							{filename}
-							{Object.keys(gist.files).length > 1 && (
+							{editingTab === filename ? (
+								<input
+									ref={tabInputRef}
+									type="text"
+									value={editingName}
+									onChange={(e) => setEditingName(e.target.value)}
+									onBlur={commitTabRename}
+									onKeyDown={(e) => {
+										if (e.key === 'Enter') {
+											e.preventDefault();
+											commitTabRename();
+										} else if (e.key === 'Escape') {
+											setEditingTab(null);
+											setEditingName('');
+										}
+									}}
+									onClick={(e) => e.stopPropagation()}
+									className="tab-rename-input"
+									aria-label={`Rename file ${filename}`}
+								/>
+							) : (
+								filename
+							)}
+							{Object.keys(gist.files).length > 1 && editingTab !== filename && (
 								<button
 									type="button"
 									onClick={(e) => {
@@ -667,8 +893,36 @@ const GistEditor = () => {
 				</div>
 			</div>
 
-			{/* Toolbar */}
-			<MarkdownToolbar onInsert={insertText} activeFile={activeFile} />
+			{/* Toolbar -- context-sensitive based on file type */}
+			{activeFile && isMarkdownFile(activeFile) ? (
+				<MarkdownToolbar onInsert={insertText} activeFile={activeFile} />
+			) : (
+				<div className="toolbar">
+					<div className="toolbar-group">
+						<button
+							type="button"
+							onClick={formatActiveFile}
+							className="toolbar-button format-button"
+							disabled={!activeFile || !canFormat || formatting}
+							title={
+								canFormat
+									? `Format file (Shift+Alt+F)`
+									: 'No formatter available for this file type'
+							}
+						>
+							{formatting ? '...' : '{ }'}
+						</button>
+						<span className="toolbar-label">
+							{formatting ? 'Formatting...' : 'Format'}
+						</span>
+					</div>
+					{activeFile && (
+						<span className="toolbar-file-type">
+							{getFileLanguage(activeFile)}
+						</span>
+					)}
+				</div>
+			)}
 
 			{/* Editor & Preview */}
 			{activeFile && (

--- a/client/src/components/GistEditor.jsx
+++ b/client/src/components/GistEditor.jsx
@@ -917,15 +917,9 @@ const GistEditor = () => {
 						>
 							{formatting ? '...' : '{ }'}
 						</button>
-						<span className="toolbar-label">
-							{formatting ? 'Formatting...' : 'Format'}
-						</span>
+						<span className="toolbar-label">{formatting ? 'Formatting...' : 'Format'}</span>
 					</div>
-					{activeFile && (
-						<span className="toolbar-file-type">
-							{getFileLanguage(activeFile)}
-						</span>
-					)}
+					{activeFile && <span className="toolbar-file-type">{getFileLanguage(activeFile)}</span>}
 				</div>
 			)}
 

--- a/client/src/components/GistEditor.jsx
+++ b/client/src/components/GistEditor.jsx
@@ -840,16 +840,21 @@ const GistEditor = () => {
 			<div className="file-tabs">
 				<div className="tabs-container">
 					{Object.keys(gist.files).map((filename) => (
-						<button
+						<div
 							key={filename}
-							type="button"
+							role="tab"
+							tabIndex={0}
 							onClick={() => setActiveFile(filename)}
 							onDoubleClick={() => {
 								setEditingTab(filename);
 								setEditingName(filename);
 							}}
+							onKeyDown={(e) => {
+								if (e.key === 'Enter' || e.key === ' ') setActiveFile(filename);
+							}}
 							className={`tab ${activeFile === filename ? 'active' : ''}`}
 							title="Double-click to rename"
+							aria-selected={activeFile === filename}
 						>
 							{editingTab === filename ? (
 								<input
@@ -888,7 +893,7 @@ const GistEditor = () => {
 									x
 								</button>
 							)}
-						</button>
+						</div>
 					))}
 				</div>
 			</div>

--- a/client/src/components/GistEditor.test.jsx
+++ b/client/src/components/GistEditor.test.jsx
@@ -175,16 +175,16 @@ describe('GistEditor Component', () => {
 			renderEditor();
 
 			const initialTabCount = screen
-				.getAllByRole('button')
-				.filter((btn) => btn.textContent.includes('untitled')).length;
+				.getAllByRole('tab')
+				.filter((tab) => tab.textContent.includes('untitled')).length;
 
 			const addBtn = screen.getByRole('button', { name: /add file/i });
 			fireEvent.click(addBtn);
 
 			await waitFor(() => {
 				const newTabCount = screen
-					.getAllByRole('button')
-					.filter((btn) => btn.textContent.includes('untitled')).length;
+					.getAllByRole('tab')
+					.filter((tab) => tab.textContent.includes('untitled')).length;
 				expect(newTabCount).toBeGreaterThan(initialTabCount);
 			});
 		});

--- a/client/src/components/GistEditor.test.jsx
+++ b/client/src/components/GistEditor.test.jsx
@@ -176,7 +176,7 @@ describe('GistEditor Component', () => {
 
 			const initialTabCount = screen
 				.getAllByRole('button')
-				.filter((btn) => btn.textContent.includes('newfile')).length;
+				.filter((btn) => btn.textContent.includes('untitled')).length;
 
 			const addBtn = screen.getByRole('button', { name: /add file/i });
 			fireEvent.click(addBtn);
@@ -184,7 +184,7 @@ describe('GistEditor Component', () => {
 			await waitFor(() => {
 				const newTabCount = screen
 					.getAllByRole('button')
-					.filter((btn) => btn.textContent.includes('newfile')).length;
+					.filter((btn) => btn.textContent.includes('untitled')).length;
 				expect(newTabCount).toBeGreaterThan(initialTabCount);
 			});
 		});

--- a/client/src/components/UserProfile.jsx
+++ b/client/src/components/UserProfile.jsx
@@ -19,7 +19,7 @@ export const UserProfile = () => {
 
 	useEffect(() => {
 		const fetchUserData = async () => {
-			if (!auth || !auth.user || !auth.token) return;
+			if (!auth?.user || !auth.token) return;
 
 			setIsLoading(true);
 			try {

--- a/client/src/components/ui/card.jsx
+++ b/client/src/components/ui/card.jsx
@@ -41,4 +41,4 @@ const CardFooter = React.forwardRef(({ className, ...props }, ref) => (
 ));
 CardFooter.displayName = 'CardFooter';
 
-export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent };
+export { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle };

--- a/client/src/components/ui/resizable.jsx
+++ b/client/src/components/ui/resizable.jsx
@@ -28,4 +28,4 @@ const ResizableHandle = ({ withHandle, className, ...props }) => (
 	</ResizablePrimitive.PanelResizeHandle>
 );
 
-export { ResizablePanelGroup, ResizablePanel, ResizableHandle };
+export { ResizableHandle, ResizablePanel, ResizablePanelGroup };

--- a/client/src/components/ui/tabs.jsx
+++ b/client/src/components/ui/tabs.jsx
@@ -41,4 +41,4 @@ const TabsContent = React.forwardRef(({ className, ...props }, ref) => (
 ));
 TabsContent.displayName = TabsPrimitive.Content.displayName;
 
-export { Tabs, TabsList, TabsTrigger, TabsContent };
+export { Tabs, TabsContent, TabsList, TabsTrigger };

--- a/client/src/services/api/auth.js
+++ b/client/src/services/api/auth.js
@@ -81,7 +81,7 @@ export const exchangeCodeForToken = async (code, codeVerifier) => {
 			code_verifier: codeVerifier,
 		});
 
-		if (!response.data || !response.data.access_token) {
+		if (!response.data?.access_token) {
 			const errorMsg =
 				response.data?.error_description || response.data?.error || 'No access token received';
 			logError('Token exchange failed', { error: errorMsg });

--- a/client/src/styles/gistEditor.css
+++ b/client/src/styles/gistEditor.css
@@ -189,6 +189,24 @@
 	background: hsl(var(--muted));
 }
 
+/* Inline rename input inside file tabs */
+.tab-rename-input {
+	background: hsl(var(--background));
+	border: 1px solid hsl(var(--ring));
+	border-radius: calc(var(--radius) - 4px);
+	color: hsl(var(--foreground));
+	font-size: 0.875rem;
+	font-family: inherit;
+	padding: 0.1rem 0.4rem;
+	width: 12ch;
+	min-width: 6ch;
+	outline: none;
+}
+
+.tab-rename-input:focus {
+	box-shadow: 0 0 0 2px hsl(var(--ring) / 0.3);
+}
+
 /* Enhanced Toolbar */
 .toolbar {
 	display: flex;
@@ -244,6 +262,29 @@
 	height: 1.5rem;
 	background: hsl(var(--border));
 	margin: 0;
+}
+
+/* Code toolbar extras */
+.toolbar-label {
+	font-size: 0.8rem;
+	color: hsl(var(--muted-foreground));
+	user-select: none;
+}
+
+.toolbar-file-type {
+	margin-left: auto;
+	font-size: 0.75rem;
+	font-weight: 500;
+	color: hsl(var(--muted-foreground));
+	text-transform: uppercase;
+	letter-spacing: 0.05em;
+	padding: 0.25rem 0.5rem;
+	background: hsl(var(--muted));
+	border-radius: calc(var(--radius) - 2px);
+}
+
+.format-button {
+	font-family: "JetBrains Mono", "Fira Code", Consolas, Monaco, monospace;
 }
 
 /* Split panel container */

--- a/client/src/utils/describeGist.js
+++ b/client/src/utils/describeGist.js
@@ -46,7 +46,7 @@ export const inferDescriptionFromMarkdown = (content = '', maxWords = 12) => {
  * @returns {Object} - Contains preview text, file info, and language detection
  */
 export const generateGistPreview = (gist, maxLength = 100) => {
-	if (!gist || !gist.files) {
+	if (!gist?.files) {
 		return {
 			preview: 'No content available',
 			fileCount: 0,

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"format": "biome format --write client/src/ server/"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "^2.4.6",
-		"concurrently": "^9.2.0"
+		"@biomejs/biome": "^2.4.10",
+		"concurrently": "^9.2.1"
 	}
 }


### PR DESCRIPTION
## Summary
- New files default to `untitled` with the tab immediately in rename mode so users set the filename (and extension) up front
- Double-click any file tab to rename inline; validates for duplicates and empty names
- Non-markdown files get a context-sensitive code toolbar with a **Format** button (also via `Shift+Alt+F`) powered by Prettier, loaded on demand via dynamic `import()`
- Markdown files retain the existing rich toolbar
- Language detection expanded from 14 to 40+ extensions for better syntax highlighting in the preview panel

## Test plan
- [x] All 47 existing tests pass
- [x] Production build succeeds (Prettier plugins code-split into separate chunks)
- [ ] Create a new gist -- verify tab starts in rename mode, type `main.js`, confirm with Enter
- [ ] Double-click an existing file tab, rename it, verify content preserved
- [ ] On a `.js` file, click Format or press Shift+Alt+F -- verify Prettier formats the content
- [ ] On a `.md` file, verify the markdown toolbar still appears (not the code toolbar)
- [ ] Try formatting a file with no extension -- verify toast error